### PR TITLE
Closes #11

### DIFF
--- a/abap/src/app_pretty_printer_rules/app_pretty_printer_rules_amdp/zcl_app_rule_amdp_default_no_c.clas.abap
+++ b/abap/src/app_pretty_printer_rules/app_pretty_printer_rules_amdp/zcl_app_rule_amdp_default_no_c.clas.abap
@@ -55,8 +55,14 @@ CLASS zcl_app_rule_amdp_default_no_c IMPLEMENTATION.
 
     IF is_logic_active( ) = abap_true.
       mv_add_indent = mr_rule_data->add_indent.
+    ELSE.
+      "If the token is a comment, then clear the rule_data,
+      "that could lead to issues with indent
+      CLEAR mr_rule_data->is_new_line_req.
+      CLEAR mr_rule_data->new_line_indent_diff.
+      CLEAR mr_rule_data->new_statement_indent_diff.
+      CLEAR mr_rule_data->add_indent.
     ENDIF.
-
 
   ENDMETHOD.
 ENDCLASS.

--- a/abap/src/zcl_app_pretty_printer.clas.abap
+++ b/abap/src/zcl_app_pretty_printer.clas.abap
@@ -7,8 +7,8 @@ CLASS zcl_app_pretty_printer DEFINITION
 
     METHODS pretty_print
       IMPORTING
-        it_source       TYPE sourcetable
-        ir_settings type ref to zif_app_settings
+        it_source        TYPE sourcetable
+        ir_settings      TYPE REF TO zif_app_settings
       RETURNING
         VALUE(rt_source) TYPE sourcetable
       RAISING
@@ -27,31 +27,31 @@ CLASS zcl_app_pretty_printer DEFINITION
         zcx_app_exception .
     METHODS get_and_apply_rules
       IMPORTING
-        it_source       TYPE sourcetable
-        it_statement    TYPE sstmnt_tab
-        it_structure    TYPE sstruc_tab
-        ir_settings     type ref to zif_app_settings
+        it_source        TYPE sourcetable
+        it_statement     TYPE sstmnt_tab
+        it_structure     TYPE sstruc_tab
+        ir_settings      TYPE REF TO zif_app_settings
       CHANGING
-        ct_token_ext    TYPE zapp_t_stokesx_ext_st
+        ct_token_ext     TYPE zapp_t_stokesx_ext_st
       RETURNING
         VALUE(rt_source) TYPE sourcetable
       RAISING
         zcx_app_exception .
     METHODS get_rules
       IMPORTING
-        it_source       TYPE sourcetable
-        it_statement    TYPE sstmnt_tab
-        it_structure    TYPE sstruc_tab
-        ir_rule_factory TYPE REF TO zcl_app_rule_factory
+        it_source        TYPE sourcetable
+        it_statement     TYPE sstmnt_tab
+        it_structure     TYPE sstruc_tab
+        ir_rule_factory  TYPE REF TO zcl_app_rule_factory
       CHANGING
-        ct_token_ext    TYPE zapp_t_stokesx_ext_st
+        ct_token_ext     TYPE zapp_t_stokesx_ext_st
       RETURNING
         VALUE(rt_result) TYPE zapp_t_rule_instances
       RAISING
         zcx_app_exception .
     METHODS get_source_code_from_rules
       IMPORTING
-        it_rules        TYPE zapp_t_rule_instances
+        it_rules         TYPE zapp_t_rule_instances
       RETURNING
         VALUE(rt_result) TYPE sourcetable
       RAISING
@@ -93,7 +93,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_APP_PRETTY_PRINTER IMPLEMENTATION.
+CLASS zcl_app_pretty_printer IMPLEMENTATION.
 
 
   METHOD add_rule_to_source.


### PR DESCRIPTION
Clear in the super class method ZCL_APP_RULE_AMDP_DEFAULT_NO_C->ZIF_APP_RULE~FINALIZE_INIT the not required rule data in case of comment to avoid indent issues